### PR TITLE
changing coordinator initialization logic

### DIFF
--- a/assets/user_data.sh
+++ b/assets/user_data.sh
@@ -140,10 +140,10 @@ echo "Starting presto..."
 systemctl enable presto.service
 systemctl start presto.service
 
-if [[ "${mode_presto}" == "coordinator" ]]; then
+if [[ "${mode_presto}" == "coordinator" ]] || [[ "${mode_presto}" == "coordinator-worker" ]]; then
     echo "Waiting for Presto Coordinator to start"
-    while ! nc -z localhost ${http_port}; do
-      sleep 5
+    while ! presto --execute='select * from system.runtime.nodes'; do
+      sleep 10
     done
     echo "Presto Coordinator is now online"
 fi


### PR DESCRIPTION
There's an additional segment for the worker which I didn't change:
if [[ "${mode_presto}" == "worker" ]]; then
  echo "Waiting for Presto Coordinator to come online at: http://${address_presto_coordinator}:${http_port}"
  while ! nc -z ${address_presto_coordinator} ${http_port}; do
      sleep 5
  done
fi

Since I'm not currently testing with workers.