### PR TITLE
Fix workers/workers-spot ASG's EC2 Classic issue

### DIFF
--- a/terraform-aws/workers-spot.tf
+++ b/terraform-aws/workers-spot.tf
@@ -20,7 +20,7 @@ resource "aws_autoscaling_group" "workers-spot" {
   max_size             = "999"
   desired_capacity     = var.count_workers_spot
   launch_configuration = aws_launch_configuration.workers-spot.id
-  vpc_zone_identifier = [for s in data.aws_subnet.subnets : s.id]
+  vpc_zone_identifier  = var.subnet_ids
 
   tag {
     key                 = "Name"

--- a/terraform-aws/workers.tf
+++ b/terraform-aws/workers.tf
@@ -47,7 +47,7 @@ resource "aws_autoscaling_group" "workers" {
   max_size             = "999"
   desired_capacity     = var.count_workers
   launch_configuration = aws_launch_configuration.workers.id
-  availability_zones   = aws_autoscaling_group.coordinator.availability_zones
+  vpc_zone_identifier  = var.subnet_ids
 
   tag {
     key                 = "Name"


### PR DESCRIPTION
Stop using [availability_zones](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#availability_zones) ASG argument which causes issues on AWS accounts which support EC2 Classic.